### PR TITLE
Refactor macOS framework code

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -22,6 +22,11 @@ to the resources directory.
 Returns a C<Str> which contains the absolute path
 to the locales directory.
 
+=head2 framework_path
+
+Returns a C<Str> with path to C<Chromium Embedded Framework> framework if on
+macOS. Returns an empty C<Str> otherwise.
+
 =head1 Inline support
 
 This module supports L<Inline's with functionality|Inline/"Playing 'with' Others">.

--- a/lib/Alien/CEF.pm
+++ b/lib/Alien/CEF.pm
@@ -31,6 +31,30 @@ sub locales_path {
 		'Resources', 'locales' );
 }
 
+=method framework_path
+
+Returns a C<Str> with path to C<Chromium Embedded Framework> framework if on
+macOS. Returns an empty C<Str> otherwise.
+
+=cut
+
+sub framework_path {
+	my ($self) = @_;
+	my $rpath = ($self->rpath)[0];
+	$^O eq 'darwin' ? "$rpath/Chromium Embedded Framework.framework" : "";
+}
+
+sub extra_linker_flags {
+	my ($self) = @_;
+	my @extra_linker_flags;
+	if( $^O eq 'darwin' ) {
+		# On macOS, link using framework, not using C<< -lcef >> as on
+		# Linux or Windows.
+		my $rpath = ($self->rpath)[0];
+		push @extra_linker_flags, qq|-F$rpath -framework 'Chromium Embedded Framework'|;
+	}
+	@extra_linker_flags;
+}
 
 with 'Alien::Role::Dino';
 

--- a/t/init.t
+++ b/t/init.t
@@ -7,16 +7,11 @@ use Alien::CEF;
 subtest 'CEF init' => sub {
 	alien_ok 'Alien::CEF';
 
-	my $rpath = (Alien::CEF->rpath)[0];
 	my $xs = do { local $/; <DATA> };
 	xs_ok {
 		xs => $xs,
 		cbuilder_link => {
-			extra_linker_flags => (
-				$^O eq 'darwin'
-				? qq|-F$rpath -framework 'Chromium Embedded Framework'|
-				: '',
-			),
+			extra_linker_flags => Alien::CEF->extra_linker_flags,
 		},
 		verbose => 0,
 	}, with_subtest {
@@ -24,7 +19,7 @@ subtest 'CEF init' => sub {
 		is $module->init(
 			Alien::CEF->resource_path,
 			Alien::CEF->locales_path,
-			( $^O eq 'darwin' ? "$rpath/Chromium Embedded Framework.framework" : "" ),
+			Alien::CEF->framework_path,
 		), 0,
 			"Initialised CEF";
 	};


### PR DESCRIPTION
Moves framework helper code into library from test so that it can be
used by other code.
